### PR TITLE
Move to version 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,30 @@
 - Supports tus v1.0.0
 - Protocol extensions supported: Creation, Termination
 - Upload progress events
-- Targets .NET Standard 2.0
 
 ## Usage
 ```c#
 var file = new FileInfo(@"path/to/file.ext");
-var client = new TusClient(ChunkSize);
-var fileUrl = await client.CreateAsync(Address, file, metadata);
-await client.UploadAsync(fileUrl, file);
+var client = new TusClient();
+var fileUrl = await client.CreateAsync(Address, file.Length, metadata);
+await client.UploadAsync(fileUrl, file, chunkSize: 5D);
+```
+
+### Progress updates
+`UploadAsync` returns an object of type `TusOperation`, which exposes an event which will report the progress of the upload.
+
+Store the return object in a variable and subscribe to the `Progressed` event for updates. The upload operation will not start until `TusOperation` is `await`ed.
+
+```c#
+var file = new FileInfo(@"path/to/file.ext");
+var client = new TusClient();
+var fileUrl = await client.CreateAsync(Address, file.Length, metadata);
+var uploadOperation = client.UploadAsync(fileUrl, file, chunkSize: 5D);
+
+uploadOperation.Progressed += (transferred, total) => 
+    System.Diagnostics.Debug.WriteLine($"Progress: {transferred}/{total}");
+    
+await uploadOperation; 
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 ```c#
 var file = new FileInfo(@"path/to/file.ext");
 var client = new TusClient(ChunkSize);
-var fileUrl = client.Create(Address, file, metadata);
-client.Upload(fileUrl, file);
+var fileUrl = await client.CreateAsync(Address, file, metadata);
+await client.UploadAsync(fileUrl, file);
 ```
 
 ## License

--- a/TusDotNetClient.sln
+++ b/TusDotNetClient.sln
@@ -7,6 +7,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TusDotNetClient", "src\TusD
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TusDotNetClientTests", "tests\TusDotNetClientTests\TusDotNetClientTests.csproj", "{AF358546-787A-45C1-95A2-0C6162A25C5E}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7A3A7595-66D1-4690-BF96-521F787946A8}"
+ProjectSection(SolutionItems) = preProject
+	README.md = README.md
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/TusDotNetClient/ProgressDelegate.cs
+++ b/src/TusDotNetClient/ProgressDelegate.cs
@@ -1,4 +1,4 @@
 namespace TusDotNetClient
 {
-    public delegate void ProgressDelegate(long bytesTransferred, long bytesTotal);
+    
 }

--- a/src/TusDotNetClient/ProgressDelegate.cs
+++ b/src/TusDotNetClient/ProgressDelegate.cs
@@ -1,4 +1,0 @@
-namespace TusDotNetClient
-{
-    
-}

--- a/src/TusDotNetClient/TusClient.cs
+++ b/src/TusDotNetClient/TusClient.cs
@@ -38,7 +38,7 @@ namespace TusDotNetClient
             _cancellationSource.Cancel();
         }
 
-        public async Task<string> CreateAsync(string url, long uploadLength, (string key, string value)[] metadata)
+        public async Task<string> CreateAsync(string url, long uploadLength, params (string key, string value)[] metadata)
         {
             var requestUri = new Uri(url);
             var client = new TusHttpClient

--- a/src/TusDotNetClient/TusClient.cs
+++ b/src/TusDotNetClient/TusClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -56,6 +56,18 @@ namespace TusDotNetClient
 
         public TusOperation<Unit> UploadAsync(string url, FileInfo file) =>
             UploadAsync(url, new FileStream(file.FullName,
+        public TusOperation<Unit> UploadAsync(
+            string url,
+            FileInfo file,
+            double chunkSize = 5.0,
+            CancellationToken cancellationToken = default) =>
+            UploadAsync(
+                url,
+                new FileStream(file.FullName,
+                    FileMode.Open, FileAccess.Read, FileShare.Read,
+                    5 * 1024 * 1024, true),
+                chunkSize,
+                cancellationToken);
                 FileMode.Open, FileAccess.Read, FileShare.Read,
                 5 * 1024 * 1024, true));
 

--- a/src/TusDotNetClient/TusClient.cs
+++ b/src/TusDotNetClient/TusClient.cs
@@ -20,7 +20,7 @@ namespace TusDotNetClient
 
         private readonly double _chunkSize;
 
-        public Dictionary<string, string> AdditionalHeaders { get; } = new Dictionary<string, string>();
+        public Dictionary<string, string> AdditionalHeaders { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         public TusClient() : this(5.0)
         {

--- a/src/TusDotNetClient/TusClient.cs
+++ b/src/TusDotNetClient/TusClient.cs
@@ -251,12 +251,12 @@ namespace TusDotNetClient
                 throw new Exception("getFileOffset failed. " + response.ResponseString);
             }
 
-            if (!response.Headers.ContainsKey("Upload-Offset"))
+            if (!response.Headers.ContainsKey(TusHeaderNames.UploadOffset))
             {
                 throw new Exception("Offset Header Missing");
             }
 
-            return long.Parse(response.Headers["Upload-Offset"]);
+            return long.Parse(response.Headers[TusHeaderNames.UploadOffset]);
         }
     }
 }

--- a/src/TusDotNetClient/TusClient.cs
+++ b/src/TusDotNetClient/TusClient.cs
@@ -50,11 +50,16 @@ namespace TusDotNetClient
         public string Create(string url, long uploadLength, Dictionary<string, string> metadata)
         {
             var requestUri = new Uri(url);
-            var client = new TusHttpClient {Proxy = Proxy};
+            var client = new TusHttpClient
+            {
+                Proxy = Proxy
+            };
 
             var request = new TusHttpRequest(url, RequestMethod.Post);
             foreach (var kvp in AdditionalHeaders)
+            {
                 request.AddHeader(kvp.Key, kvp.Value);
+            }
             request.AddHeader(TusHeaderNames.UploadLength, uploadLength.ToString());
             request.AddHeader(TusHeaderNames.ContentLength, "0");
 
@@ -65,16 +70,24 @@ namespace TusDotNetClient
             var response = client.PerformRequest(request);
 
             if (response.StatusCode != HttpStatusCode.Created)
+            {
                 throw new Exception("CreateFileInServer failed. " + response.ResponseString);
+            }
 
             if (!response.Headers.ContainsKey("Location"))
+            {
                 throw new Exception("Location Header Missing");
+            }
 
             if (!Uri.TryCreate(response.Headers["Location"], UriKind.RelativeOrAbsolute, out var locationUri))
+            {
                 throw new Exception("Invalid Location Header");
+            }
 
             if (!locationUri.IsAbsoluteUri)
+            {
                 locationUri = new Uri(requestUri, locationUri);
+            }
 
             return locationUri.ToString();
         }
@@ -93,9 +106,11 @@ namespace TusDotNetClient
             var client = new TusHttpClient();
             SHA1 sha = new SHA1Managed();
 
-            var chunkSize = (int) Math.Ceiling(_chunkSize * 1024.0 * 1024.0); // to MB
+            var chunkSize = (int)Math.Ceiling(_chunkSize * 1024.0 * 1024.0); // to MB
             if (offset == fs.Length)
+            {
                 OnUploadProgress(fs.Length, fs.Length);
+            }
 
             while (offset < fs.Length)
             {
@@ -106,7 +121,9 @@ namespace TusDotNetClient
                 var sha1Hash = sha.ComputeHash(buffer);
                 var request = new TusHttpRequest(url, RequestMethod.Patch, buffer, _cancellationSource.Token);
                 foreach (var kvp in AdditionalHeaders)
+                {
                     request.AddHeader(kvp.Key, kvp.Value);
+                }
                 request.AddHeader(TusHeaderNames.UploadOffset, offset.ToString());
                 request.AddHeader(TusHeaderNames.UploadChecksum, $"sha1 {Convert.ToBase64String(sha1Hash)}");
                 request.AddHeader(TusHeaderNames.ContentType, "application/offset+octet-stream");
@@ -149,7 +166,9 @@ namespace TusDotNetClient
             var client = new TusHttpClient();
             var request = new TusHttpRequest(url, RequestMethod.Get, null, _cancellationSource.Token);
             foreach (var kvp in AdditionalHeaders)
+            {
                 request.AddHeader(kvp.Key, kvp.Value);
+            }
             request.DownloadProgressed += OnDownloadProgress;
             var response = client.PerformRequest(request);
             return response;
@@ -160,7 +179,9 @@ namespace TusDotNetClient
             var client = new TusHttpClient();
             var request = new TusHttpRequest(url, RequestMethod.Head);
             foreach (var kvp in AdditionalHeaders)
+            {
                 request.AddHeader(kvp.Key, kvp.Value);
+            }
             try
             {
                 return client.PerformRequest(request);
@@ -176,10 +197,14 @@ namespace TusDotNetClient
             var client = new TusHttpClient();
             var request = new TusHttpRequest(url, RequestMethod.Options);
             foreach (var kvp in AdditionalHeaders)
+            {
                 request.AddHeader(kvp.Key, kvp.Value);
+            }
             var response = client.PerformRequest(request);
             if (response.StatusCode != HttpStatusCode.NoContent && response.StatusCode != HttpStatusCode.OK)
+            {
                 throw new Exception("getServerInfo failed. " + response.ResponseString);
+            }
 
             // Spec says NoContent but tusd gives OK because of browser bugs
             response.Headers.TryGetValue(TusHeaderNames.TusResumable, out var version);
@@ -195,7 +220,9 @@ namespace TusDotNetClient
             var client = new TusHttpClient();
             var request = new TusHttpRequest(url, RequestMethod.Delete);
             foreach (var kvp in AdditionalHeaders)
+            {
                 request.AddHeader(kvp.Key, kvp.Value);
+            }
             var response = client.PerformRequest(request);
 
             return response.StatusCode == HttpStatusCode.NoContent ||
@@ -214,14 +241,20 @@ namespace TusDotNetClient
             var client = new TusHttpClient();
             var request = new TusHttpRequest(url, RequestMethod.Head);
             foreach (var kvp in AdditionalHeaders)
+            {
                 request.AddHeader(kvp.Key, kvp.Value);
+            }
             var response = client.PerformRequest(request);
 
             if (response.StatusCode != HttpStatusCode.NoContent && response.StatusCode != HttpStatusCode.OK)
+            {
                 throw new Exception("getFileOffset failed. " + response.ResponseString);
+            }
 
             if (!response.Headers.ContainsKey("Upload-Offset"))
+            {
                 throw new Exception("Offset Header Missing");
+            }
 
             return long.Parse(response.Headers["Upload-Offset"]);
         }

--- a/src/TusDotNetClient/TusClient.cs
+++ b/src/TusDotNetClient/TusClient.cs
@@ -73,12 +73,12 @@ namespace TusDotNetClient
             return locationUri.ToString();
         }
 
-        public Task UploadAsync(string url, FileInfo file)
+        public async Task UploadAsync(string url, FileInfo file)
         {
             using (var fs = new FileStream(file.FullName,
                 FileMode.Open, FileAccess.Read, FileShare.Read,
                 5 * 1024 * 1024, true))
-                return UploadAsync(url, fs);
+                await UploadAsync(url, fs);
         }
 
         public async Task UploadAsync(string url, Stream fileStream)

--- a/src/TusDotNetClient/TusDotNetClient.csproj
+++ b/src/TusDotNetClient/TusDotNetClient.csproj
@@ -10,6 +10,7 @@
     <RepositoryUrl>https://github.com/Jon-Indico/TusDotNetClient</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Jon-Indico/TusDotNetClient</PackageProjectUrl>
     <License>MIT</License>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/TusDotNetClient/TusException.cs
+++ b/src/TusDotNetClient/TusException.cs
@@ -10,7 +10,6 @@ namespace TusDotNetClient
         public string ResponseContent { get; }
         public HttpStatusCode StatusCode { get; }
         public string StatusDescription { get; }
-
         public WebException OriginalException { get; }
 
         public TusException(OperationCanceledException ex)

--- a/src/TusDotNetClient/TusException.cs
+++ b/src/TusDotNetClient/TusException.cs
@@ -7,18 +7,16 @@ namespace TusDotNetClient
 {
     public class TusException : WebException
     {
-
         public string ResponseContent { get; }
         public HttpStatusCode StatusCode { get; }
         public string StatusDescription { get; }
-
 
         public WebException OriginalException { get; }
 
         public TusException(OperationCanceledException ex)
             : base(ex.Message, ex, WebExceptionStatus.RequestCanceled, null)
         {
-            OriginalException = null;           
+            OriginalException = null;
         }
 
         public TusException(TusException ex, string message)
@@ -38,12 +36,14 @@ namespace TusDotNetClient
 
             if (ex.Response is HttpWebResponse webResponse &&
                 webResponse.GetResponseStream() is Stream responseStream)
+            {
                 using (var reader = new StreamReader(responseStream))
                 {
                     StatusCode = webResponse.StatusCode;
                     StatusDescription = webResponse.StatusDescription;
                     ResponseContent = reader.ReadToEnd();
                 }
+            }
         }
 
         public string FullMessage
@@ -54,15 +54,21 @@ namespace TusDotNetClient
                 {
                     Message
                 };
-                
+
                 if (Response is WebResponse response)
+                {
                     bits.Add($"URL:{response.ResponseUri}");
-                
+                }
+
                 if (StatusCode != HttpStatusCode.OK)
+                {
                     bits.Add($"{StatusCode}:{StatusDescription}");
-                
+                }
+
                 if (!string.IsNullOrEmpty(ResponseContent))
+                {
                     bits.Add(ResponseContent);
+                }
 
                 return string.Join(Environment.NewLine, bits);
             }

--- a/src/TusDotNetClient/TusException.cs
+++ b/src/TusDotNetClient/TusException.cs
@@ -5,19 +5,46 @@ using System.Net;
 
 namespace TusDotNetClient
 {
+    /// <summary>
+    /// Represents an exception that might occur when using <see cref="TusClient"/>.
+    /// </summary>
     public class TusException : WebException
     {
+        /// <summary>
+        /// Get the content, if any, of the failed operation.
+        /// </summary>
         public string ResponseContent { get; }
+
+        /// <summary>
+        /// Get the HTTP status code, if any, of the failed operation.
+        /// </summary>
         public HttpStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// Get the description of the HTTP status code.
+        /// </summary>
         public string StatusDescription { get; }
+
+        /// <summary>
+        /// Get the original <see cref="WebException"/> that occured.
+        /// </summary>
         public WebException OriginalException { get; }
 
+        /// <summary>
+        /// Create a new instance of <see cref="TusException"/> based on an <see cref="OperationCanceledException"/>.
+        /// </summary>
+        /// <param name="ex">An <see cref="OperationCanceledException"/> to base the <see cref="TusException"/> on.</param>
         public TusException(OperationCanceledException ex)
             : base(ex.Message, ex, WebExceptionStatus.RequestCanceled, null)
         {
             OriginalException = null;
         }
 
+        /// <summary>
+        /// Create a new instance of <see cref="TusException"/> based on another <see cref="TusException"/>.
+        /// </summary>
+        /// <param name="ex">The <see cref="TusException"/> to base the new <see cref="TusException"/> on.</param>
+        /// <param name="message">Text to prefix the <see cref="Exception.Message"/> with.</param>
         public TusException(TusException ex, string message)
             : base($"{message}{ex.Message}", ex, ex.Status, ex.Response)
         {
@@ -28,6 +55,11 @@ namespace TusDotNetClient
             ResponseContent = ex.ResponseContent;
         }
 
+        /// <summary>
+        /// Create a new instance of <see cref="TusException"/> based on a <see cref="WebException"/>.
+        /// </summary>
+        /// <param name="ex">The <see cref="WebException"/> to base the new <see cref="TusException"/> on.</param>
+        /// <param name="message">Text to prefix the <see cref="Exception.Message"/> with.</param>
         public TusException(WebException ex, string message = "")
             : base($"{message}{ex.Message}", ex, ex.Status, ex.Response)
         {
@@ -45,33 +77,33 @@ namespace TusDotNetClient
             }
         }
 
-        public string FullMessage
+        /// <summary>
+        /// Get a <see cref="string"/> containing all relevant information about the <see cref="TusException"/>.
+        /// </summary>
+        /// <returns>A <see cref="string"/> containing information about the exception.</returns>
+        public override string ToString()
         {
-            get
+            var bits = new List<string>
             {
-                var bits = new List<string>
-                {
-                    Message
-                };
+                Message
+            };
 
-                if (Response is WebResponse response)
-                {
-                    bits.Add($"URL:{response.ResponseUri}");
-                }
-
-                if (StatusCode != HttpStatusCode.OK)
-                {
-                    bits.Add($"{StatusCode}:{StatusDescription}");
-                }
-
-                if (!string.IsNullOrEmpty(ResponseContent))
-                {
-                    bits.Add(ResponseContent);
-                }
-
-                return string.Join(Environment.NewLine, bits);
+            if (Response is WebResponse response)
+            {
+                bits.Add($"URL:{response.ResponseUri}");
             }
-        }
 
+            if (StatusCode != HttpStatusCode.OK)
+            {
+                bits.Add($"{StatusCode}:{StatusDescription}");
+            }
+
+            if (!string.IsNullOrEmpty(ResponseContent))
+            {
+                bits.Add(ResponseContent);
+            }
+
+            return string.Join(Environment.NewLine, bits);
+        }
     }
 }

--- a/src/TusDotNetClient/TusHTTPClient.cs
+++ b/src/TusDotNetClient/TusHTTPClient.cs
@@ -87,8 +87,7 @@ namespace TusDotNetClient
                         }
                     }
                 }
-
-
+                
                 var response = (HttpWebResponse)await webRequest.GetResponseAsync()
                     .ConfigureAwait(false);
 

--- a/src/TusDotNetClient/TusHTTPClient.cs
+++ b/src/TusDotNetClient/TusHTTPClient.cs
@@ -7,10 +7,22 @@ using System.Threading.Tasks;
 
 namespace TusDotNetClient
 {
+    /// <summary>
+    /// A class to execute requests against a Tus enabled server.
+    /// </summary>
     public class TusHttpClient
     {
+        /// <summary>
+        /// Get or set the proxy to use for requests.
+        /// </summary>
         public IWebProxy Proxy { get; set; }
 
+        /// <summary>
+        /// Perform a request to the Tus server.
+        /// </summary>
+        /// <param name="request">The <see cref="TusHttpRequest"/> to execute.</param>
+        /// <returns>A <see cref="TusHttpResponse"/> with the response data.</returns>
+        /// <exception cref="TusException">Throws when the request fails.</exception>
         public async Task<TusHttpResponse> PerformRequestAsync(TusHttpRequest request)
         {
             var segment = request.BodyBytes;

--- a/src/TusDotNetClient/TusHeaderNames.cs
+++ b/src/TusDotNetClient/TusHeaderNames.cs
@@ -1,6 +1,6 @@
 namespace TusDotNetClient
 {
-    public class TusHeaderNames
+    public static class TusHeaderNames
     {
         public const string TusResumable = "Tus-Resumable";
         public const string TusVersion = "Tus-Version";

--- a/src/TusDotNetClient/TusHeaderNames.cs
+++ b/src/TusDotNetClient/TusHeaderNames.cs
@@ -1,5 +1,8 @@
 namespace TusDotNetClient
 {
+    /// <summary>
+    /// A collection of the header names used by the Tus protocol.
+    /// </summary>
     public static class TusHeaderNames
     {
         public const string TusResumable = "Tus-Resumable";

--- a/src/TusDotNetClient/TusHeaderNames.cs
+++ b/src/TusDotNetClient/TusHeaderNames.cs
@@ -6,6 +6,7 @@ namespace TusDotNetClient
         public const string TusVersion = "Tus-Version";
         public const string TusExtension = "Tus-Extension";
         public const string TusMaxSize = "Tus-Max-Size";
+        public const string TusChecksumAlgorithm = "Tus-Checksum-Algorithm";
         public const string UploadLength = "Upload-Length";
         public const string UploadOffset = "Upload-Offset";
         public const string UploadMetadata = "Upload-Metadata";

--- a/src/TusDotNetClient/TusHttpRequest.cs
+++ b/src/TusDotNetClient/TusHttpRequest.cs
@@ -25,19 +25,19 @@ namespace TusDotNetClient
         public Uri Url { get; }
         public string Method { get; }
         public IReadOnlyDictionary<string, string> Headers => _headers;
-        public byte[] BodyBytes { get; }
+        public ArraySegment<byte> BodyBytes { get; }
 
         public CancellationToken CancelToken { get; }
 
         public TusHttpRequest(
             string url,
             RequestMethod method,
-            byte[] bodyBytes = null,
+            ArraySegment<byte> bodyBytes = default,
             CancellationToken? cancelToken = null)
         {
             Url = new Uri(url);
             Method = method.ToString().ToUpperInvariant();
-            BodyBytes = bodyBytes ?? Array.Empty<byte>();
+            BodyBytes = bodyBytes;
             CancelToken = cancelToken ?? CancellationToken.None;
             
             _headers.Add(TusHeaderNames.TusResumable, "1.0.0");

--- a/src/TusDotNetClient/TusHttpRequest.cs
+++ b/src/TusDotNetClient/TusHttpRequest.cs
@@ -16,7 +16,7 @@ namespace TusDotNetClient
 
     public class TusHttpRequest
     {
-        private readonly Dictionary<string, string> _headers = new Dictionary<string, string>();
+        private readonly Dictionary<string, string> _headers;
         
         public event ProgressDelegate UploadProgressed;
 
@@ -32,6 +32,7 @@ namespace TusDotNetClient
         public TusHttpRequest(
             string url,
             RequestMethod method,
+            IDictionary<string, string> additionalHeaders = null,
             ArraySegment<byte> bodyBytes = default,
             CancellationToken? cancelToken = null)
         {
@@ -39,7 +40,10 @@ namespace TusDotNetClient
             Method = method.ToString().ToUpperInvariant();
             BodyBytes = bodyBytes;
             CancelToken = cancelToken ?? CancellationToken.None;
-            
+
+            _headers = additionalHeaders is null
+                ? new Dictionary<string, string>(1)
+                : new Dictionary<string, string>(additionalHeaders); 
             _headers.Add(TusHeaderNames.TusResumable, "1.0.0");
         }
 

--- a/src/TusDotNetClient/TusHttpRequest.cs
+++ b/src/TusDotNetClient/TusHttpRequest.cs
@@ -4,6 +4,9 @@ using System.Threading;
 
 namespace TusDotNetClient
 {
+    /// <summary>
+    /// HTTP methods supported by <see cref="TusDotNetClient"/>
+    /// </summary>
     public enum RequestMethod
     {
         Get,
@@ -14,21 +17,52 @@ namespace TusDotNetClient
         Delete
     }
 
+    /// <summary>
+    /// A class representing a request to be sent to a Tus enabled server.
+    /// </summary>
     public class TusHttpRequest
     {
         private readonly Dictionary<string, string> _headers;
         
+        /// <summary>
+        /// Occurs when progress sending the request is made.
+        /// </summary>
         public event ProgressDelegate UploadProgressed;
 
+        /// <summary>
+        /// Occurs when progress receiving the response is made.
+        /// </summary>
         public event ProgressDelegate DownloadProgressed;
 
+        /// <summary>
+        /// Get the URL the request is being made against.
+        /// </summary>
         public Uri Url { get; }
+        /// <summary>
+        /// Get the HTTP method of the request.
+        /// </summary>
         public string Method { get; }
+        /// <summary>
+        /// Get a read-only collection of the headers of the request.
+        /// </summary>
         public IReadOnlyDictionary<string, string> Headers => _headers;
+        /// <summary>
+        /// Get the raw bytes of the content of the request.
+        /// </summary>
         public ArraySegment<byte> BodyBytes { get; }
-
+        /// <summary>
+        /// Get the cancellation token used to cancel the request.
+        /// </summary>
         public CancellationToken CancelToken { get; }
 
+        /// <summary>
+        /// Create a new request to be made against a Tus enabled server.
+        /// </summary>
+        /// <param name="url">The URL to make the request against.</param>
+        /// <param name="method">The HTTP method to use for the request.</param>
+        /// <param name="additionalHeaders">A <see cref="Dictionary{TKey,TValue}"/> of user specified headers to add to the request.</param>
+        /// <param name="bodyBytes">A byte array of the content of the request.</param>
+        /// <param name="cancelToken">A <see cref="CancellationToken"/> to cancel the request with.</param>
         public TusHttpRequest(
             string url,
             RequestMethod method,
@@ -47,11 +81,26 @@ namespace TusDotNetClient
             _headers.Add(TusHeaderNames.TusResumable, "1.0.0");
         }
 
+        /// <summary>
+        /// Add an HTTP header to request.
+        /// </summary>
+        /// <param name="key">The name of the HTTP header.</param>
+        /// <param name="value">The value of the HTTP header.</param>
         public void AddHeader(string key, string value) => _headers.Add(key, value);
 
+        /// <summary>
+        /// Invoke an <see cref="UploadProgressed"/> event.
+        /// </summary>
+        /// <param name="bytesTransferred">The number of bytes uploaded so far.</param>
+        /// <param name="bytesTotal">The total number of bytes to be uploaded.</param>
         public void OnUploadProgressed(long bytesTransferred, long bytesTotal) =>
             UploadProgressed?.Invoke(bytesTransferred, bytesTotal);
 
+        /// <summary>
+        /// Invoke an <see cref="DownloadProgressed"/> event.
+        /// </summary>
+        /// <param name="bytesTransferred">The number of bytes downloaded so far.</param>
+        /// <param name="bytesTotal">The total number of bytes to be downloaded.</param>
         public void OnDownloadProgressed(long bytesTransferred, long bytesTotal) =>
             DownloadProgressed?.Invoke(bytesTransferred, bytesTotal);
     }

--- a/src/TusDotNetClient/TusHttpResponse.cs
+++ b/src/TusDotNetClient/TusHttpResponse.cs
@@ -5,13 +5,34 @@ using System.Text;
 
 namespace TusDotNetClient
 {
+    /// <summary>
+    /// Represents a response from a request made to a Tus enabled server.
+    /// </summary>
     public class TusHttpResponse
     {
+        /// <summary>
+        /// Get the HTTP status code from the Tus server.
+        /// </summary>
         public HttpStatusCode StatusCode { get; }
+        /// <summary>
+        /// Get the HTTP headers from the response.
+        /// </summary>
         public IReadOnlyDictionary<string, string> Headers { get; }
+        /// <summary>
+        /// Get the content of the HTTP response as bytes.
+        /// </summary>
         public byte[] ResponseBytes { get; }
+        /// <summary>
+        /// Get the content of the HTTP response as a <see cref="string"/>.
+        /// </summary>
         public string ResponseString => Encoding.UTF8.GetString(ResponseBytes);
 
+        /// <summary>
+        /// Create an instance of a <see cref="TusHttpResponse"/>.
+        /// </summary>
+        /// <param name="statusCode">The HTTP status code of the response.</param>
+        /// <param name="headers">The HTTP headers of the response.</param>
+        /// <param name="responseBytes">The content of the response.</param>
         public TusHttpResponse(
             HttpStatusCode statusCode,
             IDictionary<string, string> headers = null,

--- a/src/TusDotNetClient/TusHttpResponse.cs
+++ b/src/TusDotNetClient/TusHttpResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Text;
 
@@ -6,7 +7,7 @@ namespace TusDotNetClient
 {
     public class TusHttpResponse
     {
-        private readonly Dictionary<string, string> _headers = new Dictionary<string, string>();
+        private readonly Dictionary<string, string> _headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         public HttpStatusCode StatusCode { get; }
         public IReadOnlyDictionary<string, string> Headers => _headers;

--- a/src/TusDotNetClient/TusHttpResponse.cs
+++ b/src/TusDotNetClient/TusHttpResponse.cs
@@ -7,20 +7,21 @@ namespace TusDotNetClient
 {
     public class TusHttpResponse
     {
-        private readonly Dictionary<string, string> _headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
         public HttpStatusCode StatusCode { get; }
-        public IReadOnlyDictionary<string, string> Headers => _headers;
+        public IReadOnlyDictionary<string, string> Headers { get; }
         public byte[] ResponseBytes { get; }
         public string ResponseString => Encoding.UTF8.GetString(ResponseBytes);
 
-        public TusHttpResponse(HttpStatusCode statusCode, byte[] responseBytes = null)
+        public TusHttpResponse(
+            HttpStatusCode statusCode,
+            IDictionary<string, string> headers = null,
+            byte[] responseBytes = null)
         {
             StatusCode = statusCode;
+            Headers = headers is null
+                ? new Dictionary<string, string>(0)
+                : new Dictionary<string, string>(headers);
             ResponseBytes = responseBytes;
         }
-
-        public void AddHeader(string key, string value) =>
-            _headers.Add(key, value);
     }
 }

--- a/src/TusDotNetClient/TusOperation.cs
+++ b/src/TusDotNetClient/TusOperation.cs
@@ -1,0 +1,29 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace TusDotNetClient
+{
+    public delegate void ProgressDelegate(long bytesTransferred, long bytesTotal);
+
+    public class TusOperation<T>
+    {
+        private readonly OperationDelegate _operation;
+        private Task<T> _operationTask;
+
+        public delegate Task<T> OperationDelegate(ProgressDelegate reportProgress);
+
+        public event ProgressDelegate Progressed;
+
+        public Task<T> Operation =>
+            _operationTask ??
+            (_operationTask = _operation((transferred, total) =>
+                Progressed?.Invoke(transferred, total)));
+
+        internal TusOperation(OperationDelegate operation)
+        {
+            _operation = operation;
+        }
+
+        public TaskAwaiter<T> GetAwaiter() => Operation.GetAwaiter();
+    }
+}

--- a/src/TusDotNetClient/TusOperation.cs
+++ b/src/TusDotNetClient/TusOperation.cs
@@ -3,27 +3,54 @@ using System.Threading.Tasks;
 
 namespace TusDotNetClient
 {
+    /// <summary>
+    /// A delegate used for reporting progress of a transfer of bytes.
+    /// </summary>
+    /// <param name="bytesTransferred">The number of bytes transferred so far.</param>
+    /// <param name="bytesTotal">The total number of bytes to transfer.</param>
     public delegate void ProgressDelegate(long bytesTransferred, long bytesTotal);
 
+    /// <summary>
+    /// Represents an operation against a Tus enabled server. <see cref="TusOperation{T}"/> supports progress reports.
+    /// </summary>
+    /// <typeparam name="T">The type of the operation result.</typeparam>
     public class TusOperation<T>
     {
         private readonly OperationDelegate _operation;
         private Task<T> _operationTask;
 
+        /// <summary>
+        /// Represents an operation which receives a delegate to report transfer progress to.
+        /// </summary>
+        /// <param name="reportProgress">A delegate which transfer progress can be reported to.</param>
         public delegate Task<T> OperationDelegate(ProgressDelegate reportProgress);
 
+        /// <summary>
+        /// Occurs when progress sending the request is made.
+        /// </summary>
         public event ProgressDelegate Progressed;
 
+        /// <summary>
+        /// Get the asynchronous operation to be performed. This will initiate the operation.
+        /// </summary>
         public Task<T> Operation =>
             _operationTask ??
             (_operationTask = _operation((transferred, total) =>
                 Progressed?.Invoke(transferred, total)));
 
+        /// <summary>
+        /// Create an instance of a <see cref="TusOperation{T}"/>
+        /// </summary>
+        /// <param name="operation">The operation to perform.</param>
         internal TusOperation(OperationDelegate operation)
         {
             _operation = operation;
         }
 
+        /// <summary>
+        /// Gets an awaiter used to initiate and await the operation.
+        /// </summary>
+        /// <returns>The <see cref="TaskAwaiter{TResult}"/> of the underlying <see cref="Task{TResult}"/>.</returns>
         public TaskAwaiter<T> GetAwaiter() => Operation.GetAwaiter();
     }
 }

--- a/src/TusDotNetClient/TusServerInfo.cs
+++ b/src/TusDotNetClient/TusServerInfo.cs
@@ -14,11 +14,11 @@ namespace TusDotNetClient
         /// <summary>
         /// Get a list of versions of the protocol the Tus server supports.
         /// </summary>
-        public string SupportedVersions { get; }
+        public string[] SupportedVersions { get; }
         /// <summary>
         /// Get the protocol extensions supported by the Tus server.
         /// </summary>
-        public string Extensions { get; }
+        public string[] Extensions { get; }
         /// <summary>
         /// Get the maximum total size of a single file supported by the Tus server. 
         /// </summary>
@@ -49,8 +49,8 @@ namespace TusDotNetClient
             string checksumAlgorithms)
         {
             Version = version ?? "";
-            SupportedVersions = supportedVersions ?? "";
-            Extensions = extensions ?? "";
+            SupportedVersions = (supportedVersions ?? "").Trim().Split(',').ToArray();
+            Extensions = (extensions ?? "").Trim().Split(',').ToArray();
             MaxSize = maxSize ?? 0;
             SupportedChecksumAlgorithms = (checksumAlgorithms ?? "").Trim().Split(',').ToArray();
         }

--- a/src/TusDotNetClient/TusServerInfo.cs
+++ b/src/TusDotNetClient/TusServerInfo.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace TusDotNetClient
 {
     public partial class TusClient
@@ -7,16 +9,23 @@ namespace TusDotNetClient
             public string Version { get; }
             public string SupportedVersions { get; }
             public string Extensions { get; }
-            public ulong MaxSize { get; }
+            public long MaxSize { get; }
+            public string[] SupportedChecksumAlgorithms { get; }
 
             public bool SupportsDelete => Extensions.Contains("termination");
 
-            public TusServerInfo(string version, string supportedVersions, string extensions, ulong? maxSize)
+            public TusServerInfo(
+                string version,
+                string supportedVersions,
+                string extensions,
+                long? maxSize,
+                string checksumAlgorithms)
             {
                 Version = version ?? "";
                 SupportedVersions = supportedVersions ?? "";
                 Extensions = extensions ?? "";
                 MaxSize = maxSize ?? 0;
+                SupportedChecksumAlgorithms = (checksumAlgorithms ?? "").Trim().Split(',').ToArray();
             }
         }
     }

--- a/src/TusDotNetClient/TusServerInfo.cs
+++ b/src/TusDotNetClient/TusServerInfo.cs
@@ -2,31 +2,57 @@ using System.Linq;
 
 namespace TusDotNetClient
 {
-    public partial class TusClient
+    /// <summary>
+    /// Represents information about a Tus enabled server.
+    /// </summary>
+    public class TusServerInfo
     {
-        public class TusServerInfo
+        /// <summary>
+        /// Get the version of the Tus protocol used by the Tus server.
+        /// </summary>
+        public string Version { get; }
+        /// <summary>
+        /// Get a list of versions of the protocol the Tus server supports.
+        /// </summary>
+        public string SupportedVersions { get; }
+        /// <summary>
+        /// Get the protocol extensions supported by the Tus server.
+        /// </summary>
+        public string Extensions { get; }
+        /// <summary>
+        /// Get the maximum total size of a single file supported by the Tus server. 
+        /// </summary>
+        public long MaxSize { get; }
+        /// <summary>
+        /// Get the checksum algorithms supported by the Tus server.
+        /// </summary>
+        public string[] SupportedChecksumAlgorithms { get; }
+
+        /// <summary>
+        /// Get whether the <c>termination</c> protocol extension is supported by the Tus server.
+        /// </summary>
+        public bool SupportsDelete => Extensions.Contains("termination");
+
+        /// <summary>
+        /// Create a new instance of <see cref="TusServerInfo"/>.
+        /// </summary>
+        /// <param name="version">The protocol version used by the Tus server.</param>
+        /// <param name="supportedVersions">The versions of the protocol supported by the Tus server separated by commas.</param>
+        /// <param name="extensions">The protocol extensions supported by the Tus server separated by commas.</param>
+        /// <param name="maxSize">The maximum total size of a single file supported by the Tus server.</param>
+        /// <param name="checksumAlgorithms">The checksum algorithms supported by the Tus server separated by the Tus server.</param>
+        public TusServerInfo(
+            string version,
+            string supportedVersions,
+            string extensions,
+            long? maxSize,
+            string checksumAlgorithms)
         {
-            public string Version { get; }
-            public string SupportedVersions { get; }
-            public string Extensions { get; }
-            public long MaxSize { get; }
-            public string[] SupportedChecksumAlgorithms { get; }
-
-            public bool SupportsDelete => Extensions.Contains("termination");
-
-            public TusServerInfo(
-                string version,
-                string supportedVersions,
-                string extensions,
-                long? maxSize,
-                string checksumAlgorithms)
-            {
-                Version = version ?? "";
-                SupportedVersions = supportedVersions ?? "";
-                Extensions = extensions ?? "";
-                MaxSize = maxSize ?? 0;
-                SupportedChecksumAlgorithms = (checksumAlgorithms ?? "").Trim().Split(',').ToArray();
-            }
+            Version = version ?? "";
+            SupportedVersions = supportedVersions ?? "";
+            Extensions = extensions ?? "";
+            MaxSize = maxSize ?? 0;
+            SupportedChecksumAlgorithms = (checksumAlgorithms ?? "").Trim().Split(',').ToArray();
         }
     }
 }

--- a/src/TusDotNetClient/TusServerInfo.cs
+++ b/src/TusDotNetClient/TusServerInfo.cs
@@ -7,11 +7,11 @@ namespace TusDotNetClient
             public string Version { get; }
             public string SupportedVersions { get; }
             public string Extensions { get; }
-            public long MaxSize { get; }
+            public ulong MaxSize { get; }
 
             public bool SupportsDelete => Extensions.Contains("termination");
 
-            public TusServerInfo(string version, string supportedVersions, string extensions, long? maxSize)
+            public TusServerInfo(string version, string supportedVersions, string extensions, ulong? maxSize)
             {
                 Version = version ?? "";
                 SupportedVersions = supportedVersions ?? "";

--- a/src/TusDotNetClient/Unit.cs
+++ b/src/TusDotNetClient/Unit.cs
@@ -1,0 +1,7 @@
+namespace TusDotNetClient
+{
+    public struct Unit
+    {
+        public static Unit Default = new Unit();
+    }
+}

--- a/src/TusDotNetClient/Unit.cs
+++ b/src/TusDotNetClient/Unit.cs
@@ -1,5 +1,8 @@
 namespace TusDotNetClient
 {
+    /// <summary>
+    /// An empty struct which represents an empty value.
+    /// </summary>
     public struct Unit
     {
         public static Unit Default = new Unit();

--- a/tests/TusDotNetClientTests/Fixture.cs
+++ b/tests/TusDotNetClientTests/Fixture.cs
@@ -10,11 +10,35 @@ namespace TusDotNetClientTests
     {
         private readonly Process _tusProcess;
 
-        public static DirectoryInfo DataDirectory;
+        public static readonly DirectoryInfo DataDirectory;
+
+        static Fixture()
+        {
+            DataDirectory = Directory.CreateDirectory("data");
+
+            var smallTextFile = new FileInfo(Path.Combine(DataDirectory.FullName, "small_text_file.txt"));
+            File.WriteAllText(smallTextFile.FullName, Guid.NewGuid().ToString());
+
+            var largeSampleFile = new FileInfo(Path.Combine(DataDirectory.FullName, "large_sample_file.bin"));
+            using (var fileStream = new FileStream(largeSampleFile.FullName, FileMode.Create, FileAccess.Write))
+            {
+                var bytes = new byte[1024 * 1024];
+                foreach (var _ in Enumerable.Range(0, 50))
+                {
+                    new Random().NextBytes(bytes);
+                    fileStream.Write(bytes, 0, bytes.Length);
+                }
+            }
+
+            TestFiles = new[]
+            {
+                new[] {smallTextFile},
+                new[] {largeSampleFile},
+            };
+        }
 
         public Fixture()
         {
-            DataDirectory = Directory.CreateDirectory("data");
             _tusProcess = Process.Start(new DirectoryInfo(Directory.GetCurrentDirectory())
                                             .Parent?
                                             .Parent?
@@ -26,22 +50,7 @@ namespace TusDotNetClientTests
                                             "tusd executable must be present in test project directory"));
         }
 
-        public static IEnumerable<object[]> GetTestFiles()
-        {
-            var smallTextFile = new FileInfo(Path.Combine(DataDirectory.FullName, "small_text_file.txt"));
-            File.WriteAllText(smallTextFile.FullName, Guid.NewGuid().ToString());
-            yield return new[] {smallTextFile};
-
-            var largeSampleFile = new FileInfo(Path.Combine(DataDirectory.FullName, "large_sample_file.bin"));
-            using (var fileStream = new FileStream(largeSampleFile.FullName, FileMode.Create, FileAccess.Write))
-            {
-                var bytes = new byte[50 * 1024 * 1024];
-                new Random().NextBytes(bytes);
-                fileStream.Write(bytes, 0, bytes.Length);
-            }
-
-            yield return new[] {largeSampleFile};
-        }
+        public static IEnumerable<object[]> TestFiles { get; }
 
         public void Dispose()
         {

--- a/tests/TusDotNetClientTests/TusClientTests.cs
+++ b/tests/TusDotNetClientTests/TusClientTests.cs
@@ -18,7 +18,7 @@ namespace TusDotNetClientTests
         }
         
         [Theory]
-        [MemberData(nameof(Fixture.GetTestFiles), MemberType = typeof(Fixture))]
+        [MemberData(nameof(Fixture.TestFiles), MemberType = typeof(Fixture))]
         public async Task AfterCallingCreate_DataShouldContainAFile(FileInfo file)
         {
             var sut = new TusClient();
@@ -33,7 +33,7 @@ namespace TusDotNetClientTests
         }
 
         [Theory]
-        [MemberData(nameof(Fixture.GetTestFiles), MemberType = typeof(Fixture))]
+        [MemberData(nameof(Fixture.TestFiles), MemberType = typeof(Fixture))]
         public async Task AfterCallingCreateAndUpload_UploadedFileShouldBeTheSameAsTheOriginalFile(FileInfo file)
         {
             var sut = new TusClient();
@@ -56,7 +56,7 @@ namespace TusDotNetClientTests
         }
 
         [Theory]
-        [MemberData(nameof(Fixture.GetTestFiles), MemberType = typeof(Fixture))]
+        [MemberData(nameof(Fixture.TestFiles), MemberType = typeof(Fixture))]
         public async Task AfterCallingDownload_DownloadedFileShouldBeTheSameAsTheOriginalFile(FileInfo file)
         {
             var sut = new TusClient();
@@ -74,7 +74,7 @@ namespace TusDotNetClientTests
         }
 
         [Theory]
-        [MemberData(nameof(Fixture.GetTestFiles), MemberType = typeof(Fixture))]
+        [MemberData(nameof(Fixture.TestFiles), MemberType = typeof(Fixture))]
         public async Task CallingHead_ShouldReturnProgressOfUploadedFile(FileInfo file)
         {
             var sut = new TusClient();
@@ -103,7 +103,7 @@ namespace TusDotNetClientTests
         }
 
         [Theory]
-        [MemberData(nameof(Fixture.GetTestFiles), MemberType = typeof(Fixture))]
+        [MemberData(nameof(Fixture.TestFiles), MemberType = typeof(Fixture))]
         public async Task CallingDelete_ShouldRemoveUploadedFile(FileInfo file)
         {
             var sut = new TusClient();

--- a/tests/TusDotNetClientTests/TusClientTests.cs
+++ b/tests/TusDotNetClientTests/TusClientTests.cs
@@ -98,8 +98,8 @@ namespace TusDotNetClientTests
             var response = await sut.GetServerInfo("http://localhost:1080/files/");
 
             response.Version.ShouldNotBeNullOrWhiteSpace();
-            response.Extensions.ShouldNotBeNullOrWhiteSpace();
-            response.SupportedVersions.ShouldNotBeNullOrWhiteSpace();
+            response.Extensions.ShouldNotBeEmpty();
+            response.SupportedVersions.ShouldNotBeEmpty();
         }
 
         [Theory]

--- a/tests/TusDotNetClientTests/TusClientTests.cs
+++ b/tests/TusDotNetClientTests/TusClientTests.cs
@@ -80,9 +80,9 @@ namespace TusDotNetClientTests
             var sut = new TusClient();
 
             var url = await sut.CreateAsync("http://localhost:1080/files/", file);
-            var headBeforeUpload = await sut.Head(url);
+            var headBeforeUpload = await sut.HeadAsync(url);
             await sut.UploadAsync(url, file);
-            var headAfterUpload = await sut.Head(url);
+            var headAfterUpload = await sut.HeadAsync(url);
 
             headBeforeUpload.Headers.Keys.ShouldContain("Upload-Offset");
             headBeforeUpload.Headers["Upload-Offset"].ShouldBe("0");
@@ -111,7 +111,7 @@ namespace TusDotNetClientTests
 
             var url = await sut.CreateAsync("http://localhost:1080/files/", file);
             await sut.UploadAsync(url, file);
-            var uploadHeadResponse = await sut.Head(url);
+            var uploadHeadResponse = await sut.HeadAsync(url);
             var deleteResult = await sut.Delete(url);
 
 

--- a/tests/TusDotNetClientTests/TusClientTests.cs
+++ b/tests/TusDotNetClientTests/TusClientTests.cs
@@ -25,7 +25,7 @@ namespace TusDotNetClientTests
 
             var url = await sut.CreateAsync(
                 "http://localhost:1080/files/",
-                file);
+                file.Length);
 
             var upload = new FileInfo(Path.Combine(_dataDirectoryPath, $"{url.Split('/').Last()}.bin"));
             upload.Exists.ShouldBe(true);
@@ -38,7 +38,7 @@ namespace TusDotNetClientTests
         {
             var sut = new TusClient();
 
-            var url = await sut.CreateAsync("http://localhost:1080/files/", file);
+            var url = await sut.CreateAsync("http://localhost:1080/files/", file.Length);
             await sut.UploadAsync(url, file);
             
             var upload = new FileInfo(Path.Combine(_dataDirectoryPath, $"{url.Split('/').Last()}.bin"));
@@ -61,7 +61,7 @@ namespace TusDotNetClientTests
         {
             var sut = new TusClient();
 
-            var url = await sut.CreateAsync("http://localhost:1080/files/", file);
+            var url = await sut.CreateAsync("http://localhost:1080/files/", file.Length);
             await sut.UploadAsync(url, file);
             var response = await sut.DownloadAsync(url);
             
@@ -79,7 +79,7 @@ namespace TusDotNetClientTests
         {
             var sut = new TusClient();
 
-            var url = await sut.CreateAsync("http://localhost:1080/files/", file);
+            var url = await sut.CreateAsync("http://localhost:1080/files/", file.Length);
             var headBeforeUpload = await sut.HeadAsync(url);
             await sut.UploadAsync(url, file);
             var headAfterUpload = await sut.HeadAsync(url);
@@ -109,7 +109,7 @@ namespace TusDotNetClientTests
             var sut = new TusClient();
 
 
-            var url = await sut.CreateAsync("http://localhost:1080/files/", file);
+            var url = await sut.CreateAsync("http://localhost:1080/files/", file.Length);
             await sut.UploadAsync(url, file);
             var uploadHeadResponse = await sut.HeadAsync(url);
             var deleteResult = await sut.Delete(url);

--- a/tests/TusDotNetClientTests/TusDotNetClientTests.csproj
+++ b/tests/TusDotNetClientTests/TusDotNetClientTests.csproj
@@ -4,6 +4,12 @@
         <TargetFramework>netcoreapp2.2</TargetFramework>
 
         <IsPackable>false</IsPackable>
+
+        <ApplicationIcon />
+
+        <OutputType>Exe</OutputType>
+
+        <StartupObject />
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This pulls in the changes from #1 and makes a few more changes to the public API. This library will start being used in production and a bump to v1 is appropriate according to SemVer