### PR TITLE
using a FIPS compliance algorithm to calculate hash

### DIFF
--- a/src/TusDotNetClient/TusClient.cs
+++ b/src/TusDotNetClient/TusClient.cs
@@ -145,7 +145,7 @@ namespace TusDotNetClient
                             .ConfigureAwait(false);
 
                         var client = new TusHttpClient();
-                        SHA1 sha = new SHA1Managed();
+                        System.Security.Cryptography.SHA1CryptoServiceProvider sha = new System.Security.Cryptography.SHA1CryptoServiceProvider();
 
                         var uploadChunkSize = ChunkSizeToMB(chunkSize);
 


### PR DESCRIPTION
I found that curren class to calculate Hash is raising errors when FIPS is enabled in windows, this change fixes it by using a library that is FIPS compliance and generates the same hash as the previous one