### PR TITLE
Support case insensitive headers

### DIFF
--- a/src/TusDotNetClient/TusHttpRequest.cs
+++ b/src/TusDotNetClient/TusHttpRequest.cs
@@ -76,8 +76,8 @@ namespace TusDotNetClient
             CancelToken = cancelToken ?? CancellationToken.None;
 
             _headers = additionalHeaders is null
-                ? new Dictionary<string, string>(1)
-                : new Dictionary<string, string>(additionalHeaders); 
+                ? new Dictionary<string, string>(1, StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(additionalHeaders, StringComparer.OrdinalIgnoreCase); 
             _headers.Add(TusHeaderNames.TusResumable, "1.0.0");
         }
 

--- a/src/TusDotNetClient/TusHttpResponse.cs
+++ b/src/TusDotNetClient/TusHttpResponse.cs
@@ -40,8 +40,8 @@ namespace TusDotNetClient
         {
             StatusCode = statusCode;
             Headers = headers is null
-                ? new Dictionary<string, string>(0)
-                : new Dictionary<string, string>(headers);
+                ? new Dictionary<string, string>(0, StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
             ResponseBytes = responseBytes;
         }
     }


### PR DESCRIPTION
Dear Mr. Jonstodle:
According to the official documentation, the HTTP headers are case-insensitive.
I would be grateful if you could add this modification to your library.

Source:
https://www.rfc-editor.org/rfc/rfc7230#section-3.2
> Each header field consists of a case-insensitive field name followed
> by a colon (":"), optional leading whitespace, the field value, and
> optional trailing whitespace.

Thanks in advance.